### PR TITLE
Fix Active Courses count

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Teacher/Dashboard.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Teacher/Dashboard.razor
@@ -10,7 +10,7 @@
 
 <PageTitle>Dashboard – Lexicon LMS</PageTitle>
 
-<Statistics ActiveCourses="@GetActiveCoursesNumber()" TotalStudents="@TotalStudents" AssignmentsToGrade=1 />
+<Statistics ActiveCourses="@totalCount" TotalStudents="@TotalStudents" AssignmentsToGrade=1 />
 
 <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap gap-2">
     <h4 class="fw-bold mb-0">Courses</h4>

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Teacher/Dashboard.razor.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Teacher/Dashboard.razor.cs
@@ -23,7 +23,6 @@ namespace LMS.Blazor.Client.Pages.Teacher
         protected int TotalActiveCourses { get; set; }
 
         protected List<CourseDetailsDto> Courses { get; set; } = new();
-        protected List<CourseDetailsDto> UnfilteredCourses { get; set; } = new();
         protected List<ModuleDto> modulesList { get; set; } = new();
 
         protected int currentPage = 1;
@@ -106,9 +105,6 @@ namespace LMS.Blazor.Client.Pages.Teacher
                     Navigation.NavigateTo(navUri, forceLoad: false);
                 }
 
-                var UnfilteredDto = await ApiService.GetAsync<CourseSummaryPagedDto>("api/courses/summary");
-                UnfilteredCourses = UnfilteredDto?.Items;
-
                 var dto = await ApiService.GetAsync<CourseSummaryPagedDto>(url);
                 // Map returned CourseSummaryDto items (from controller) to CourseDetailsDto used in UI
                 Courses = dto?.Items.Select(i => new CourseDetailsDto
@@ -122,7 +118,7 @@ namespace LMS.Blazor.Client.Pages.Teacher
                     ModulesCount = i.ModulesCount,
                     Active = i.Active
                 }).ToList() ?? new();
-                totalCount = dto?.Total ?? 0;
+                totalCount = dto?.TotalActiveCourses ?? 0;
             }
             catch (Exception ex)
             {
@@ -158,12 +154,6 @@ namespace LMS.Blazor.Client.Pages.Teacher
         protected void NavigateToCourses()
         {
             Navigation.NavigateTo($"/teacher/managecourses");
-        }
-
-        protected int GetActiveCoursesNumber()
-        {
-            var list = UnfilteredCourses;
-            return list?.Count(c => c.Active ?? false) ?? 0;
         }
     }
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Teacher/Dashboard.razor.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Teacher/Dashboard.razor.cs
@@ -1,9 +1,10 @@
-using Microsoft.AspNetCore.Components;
-using System.Threading;
-using System.Linq;
+using Domain.Models.Entities;
+using LMS.Blazor.Client.Services;
 using LMS.Shared.DTOs.Course;
 using LMS.Shared.DTOs.Module;
-using LMS.Blazor.Client.Services;
+using Microsoft.AspNetCore.Components;
+using System.Linq;
+using System.Threading;
 
 namespace LMS.Blazor.Client.Pages.Teacher
 {
@@ -19,8 +20,10 @@ namespace LMS.Blazor.Client.Pages.Teacher
         protected bool _showSuccessMessage;
         protected string? successMessage;
         protected int TotalStudents { get; set; }
+        protected int TotalActiveCourses { get; set; }
 
         protected List<CourseDetailsDto> Courses { get; set; } = new();
+        protected List<CourseDetailsDto> UnfilteredCourses { get; set; } = new();
         protected List<ModuleDto> modulesList { get; set; } = new();
 
         protected int currentPage = 1;
@@ -103,6 +106,9 @@ namespace LMS.Blazor.Client.Pages.Teacher
                     Navigation.NavigateTo(navUri, forceLoad: false);
                 }
 
+                var UnfilteredDto = await ApiService.GetAsync<CourseSummaryPagedDto>("api/courses/summary");
+                UnfilteredCourses = UnfilteredDto?.Items;
+
                 var dto = await ApiService.GetAsync<CourseSummaryPagedDto>(url);
                 // Map returned CourseSummaryDto items (from controller) to CourseDetailsDto used in UI
                 Courses = dto?.Items.Select(i => new CourseDetailsDto
@@ -154,9 +160,9 @@ namespace LMS.Blazor.Client.Pages.Teacher
             Navigation.NavigateTo($"/teacher/managecourses");
         }
 
-        protected int GetActiveCoursesNumber(IEnumerable<CourseDetailsDto>? courses = null)
+        protected int GetActiveCoursesNumber()
         {
-            var list = courses ?? Courses;
+            var list = UnfilteredCourses;
             return list?.Count(c => c.Active ?? false) ?? 0;
         }
     }

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -98,13 +98,14 @@ public class CoursesController : ControllerBase
     [Authorize(Roles = "Teacher")]
     public async Task<IActionResult> GetCourseSummaries([FromQuery] string? search, [FromQuery] bool? active, [FromQuery] int page = 1, [FromQuery] int pageSize = 12)
     {
-        var (items, total) = await _serviceManager.CourseService.GetCourseSummariesAsync(search, active, page, pageSize);
+        var (items, total, totalActiveCourses) = await _serviceManager.CourseService.GetCourseSummariesAsync(search, active, page, pageSize);
 
         // Return CourseDetailsDto items directly in the paged response
         var dto = new
         {
             Items = items,
-            Total = total
+            Total = total,
+            TotalActiveCourses = totalActiveCourses
         };
 
         return Ok(dto);

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -25,9 +25,10 @@ public class CourseService : ICourseService
         _userManager = userManager;
     }
 
-    public async Task<(IEnumerable<CourseDetailsDto> Items, int TotalCount)> GetCourseSummariesAsync(string? search = null, bool? active = null, int page = 1, int pageSize = 12)
+    public async Task<(IEnumerable<CourseDetailsDto> Items, int TotalCount, int TotalActiveCourses)> GetCourseSummariesAsync(string? search = null, bool? active = null, int page = 1, int pageSize = 12)
     {
         var query = _uow.CourseRepository.GetCourseSummariesQuery();
+        var totalActiveCourses = await query.CountAsync(c => c.Active == true);
 
         if (!string.IsNullOrWhiteSpace(search))
         {
@@ -49,7 +50,7 @@ public class CourseService : ICourseService
             .Take(pageSize)
             .ToListAsync();
         
-        return (items, totalCount);
+        return (items, totalCount, totalActiveCourses);
     }
 
     public async Task<IEnumerable<CourseDetailsDto>> GetAllCoursesAsync(bool trackChanges = false)

--- a/LMS.Shared/DTOs/Course/CourseSummaryPagedDto.cs
+++ b/LMS.Shared/DTOs/Course/CourseSummaryPagedDto.cs
@@ -6,5 +6,7 @@ namespace LMS.Shared.DTOs.Course
     {
         public List<CourseDetailsDto> Items { get; set; } = new();
         public int Total { get; set; }
+
+        public int TotalActiveCourses { get; set; } = 0;
     }
 }

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -14,6 +14,6 @@ public interface ICourseService
     Task DeleteCourseAsync(Guid id, bool trackChanges);
     Task AddStudentToCourseAsync(Guid courseId, string studentId);
     Task<IEnumerable<AvailableStudentDto>> GetAvailableStudentsAsync();
-    Task<(IEnumerable<CourseDetailsDto> Items, int TotalCount)> GetCourseSummariesAsync(string? search = null, bool? active = null, int page = 1, int pageSize = 12);
+    Task<(IEnumerable<CourseDetailsDto> Items, int TotalCount, int TotalActiveCourses)> GetCourseSummariesAsync(string? search = null, bool? active = null, int page = 1, int pageSize = 12);
     Task<IEnumerable<UserDto>> GetParticipantsAsync(Guid courseId);
 }    


### PR DESCRIPTION
Now the Active Courses in the Statistics widget will always show the total active courses, regardless of filters.